### PR TITLE
Fix version files' URL properties

### DIFF
--- a/GameData/LazyPainter/LazyPainter.version
+++ b/GameData/LazyPainter/LazyPainter.version
@@ -1,6 +1,6 @@
 {
   "NAME": "LazyPainter",
-  "URL": "https://raw.githubusercontent.com/Halbann/LazyPainter/master/GameData/LazyPainter/LazyPainter.version",
+  "URL": "https://raw.githubusercontent.com/Halbann/LazyPainter/main/GameData/LazyPainter/LazyPainter.version",
   "DOWNLOAD": "https://github.com/Halbann/LazyPainter/releases",
   "VERSION": {
     "MAJOR": 0,

--- a/LazyPainter.version
+++ b/LazyPainter.version
@@ -1,6 +1,6 @@
 {
   "NAME": "LazyPainter",
-  "URL": "https://raw.githubusercontent.com/Halbann/LazyPainter/master/GameData/LazyPainter/LazyPainter.version",
+  "URL": "https://raw.githubusercontent.com/Halbann/LazyPainter/main/GameData/LazyPainter/LazyPainter.version",
   "DOWNLOAD": "https://github.com/Halbann/LazyPainter/releases",
   "VERSION": {
     "MAJOR": 0,


### PR DESCRIPTION
Hi @Halbann,

The repo has a `main` branch, but the URLs in the version files have `master` instead. Now it's fixed.

Noticed while reviewing KSP-CKAN/NetKAN#10249.

![image](https://github.com/user-attachments/assets/859ea9ac-e605-4d44-ad97-25649a5f495c)
